### PR TITLE
Change play button on click and stop overlapping playback

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -39,17 +39,20 @@ class App extends Component {
     newComposition.push(clickedMelody);
   }
 
-  handleRobotPlayToggled(i, play) {
-    console.log(`Toggled play to ${play} for robot ${i}`);
-    const bot = { ...this.state.bots[i], metric: 0 + play };
-    const bots = [...this.state.bots];
-    bots[i] = bot;
-    this.setState({ ...this.state, bots });
+  handleRobotPlayToggled(i, isPlaying) {
+    console.log(`Toggled play to ${isPlaying} for robot ${i}`);
+    // Increment robot play counter if robot is being played.
+    if (isPlaying) {
+      const bot = { ...this.state.bots[i], playCount: (this.state.bots[i].playCount || 0) + 1 };
+      const bots = [...this.state.bots];
+      bots[i] = bot;
+      this.setState({ ...this.state, bots });
+    }
   }
 
-  handleRobotFavouriteToggled(i, favourite) {
-    console.log(`Toggled favourite to ${favourite} for robot ${i}`);
-    const bot = { ...this.state.bots[i], metric: 0 + favourite };
+  handleRobotFavouriteToggled(i, isFavourite) {
+    console.log(`Toggled favourite to ${isFavourite} for robot ${i}`);
+    const bot = { ...this.state.bots[i], metric: 0 + isFavourite };
     const bots = [...this.state.bots];
     bots[i] = bot;
     this.setState({ ...this.state, bots });

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,6 +12,7 @@ class App extends Component {
       bots: [],
       composition: [],
     };
+    this.handleRobotPlayToggled = this.handleRobotPlayToggled.bind(this);
     this.handleRobotFavouriteToggled = this.handleRobotFavouriteToggled.bind(this);
     this.handleClearClick = this.handleClearClick.bind(this);
     this.generateBots = this.generateBots.bind(this);
@@ -38,6 +39,14 @@ class App extends Component {
     newComposition.push(clickedMelody);
   }
 
+  handleRobotPlayToggled(i, play) {
+    console.log(`Toggled play to ${play} for robot ${i}`);
+    const bot = { ...this.state.bots[i], metric: 0 + play };
+    const bots = [...this.state.bots];
+    bots[i] = bot;
+    this.setState({ ...this.state, bots });
+  }
+
   handleRobotFavouriteToggled(i, favourite) {
     console.log(`Toggled favourite to ${favourite} for robot ${i}`);
     const bot = { ...this.state.bots[i], metric: 0 + favourite };
@@ -56,6 +65,7 @@ class App extends Component {
       <MDBContainer id="App">
         <TopPanel
           bots={this.state.bots}
+          onPlayToggled={this.handleRobotPlayToggled}
           onFavouriteToggled={this.handleRobotFavouriteToggled}
           playMelody={this.playMelody}
           generateBots={this.generateBots}

--- a/client/src/Components/Robot.js
+++ b/client/src/Components/Robot.js
@@ -20,43 +20,32 @@ const COLOUR_MAP = {
 class Robot extends Component {
   constructor() {
     super();
-    this.state = { play: false, favourite: false, end_time: 0 };
-    this.handlePlayClick = this.handlePlayClick.bind(this);
-    this.handlePlayToggled = this.handlePlayToggled.bind(this);
-    this.handleFavouriteToggled = this.handleFavouriteToggled.bind(this);
+    this.state = { isFavourite: false };
+    this.handlePlayClicked = this.handlePlayClicked.bind(this);
+    this.handleFavouriteClicked = this.handleFavouriteClicked.bind(this);
   }
 
-  handlePlayClick() {
-    if (this.state.play) {
-      Tone.Transport.cancel();
-      this.handlePlayToggled();
-      return;
-    }
+  handlePlayClicked(e) {
+    const isPlaying = this.props.isPlaying;
+    this.props.onPlayToggled(!isPlaying);
 
-    this.handlePlayToggled();
-    // Tone.Timeline.cancelBefore(Tone.Transport.time);
-    // BUG: When multiple bots are clicked consecutively, the previous bots play buttons don't return to normal
-    // because the event is cleared from the timeline by the following line
+    // Stop any melodies which are currently playing.
     Tone.Transport.cancel();
+
+    if (isPlaying) return;
 
     const melody = this.props.melody.notes.map((note) => note.note);
     play(melody);
 
-    this.end_time = Tone.Transport.seconds + 2;
+    const endTime = Tone.Transport.seconds + 2;
     Tone.Transport.schedule((time) => {
-      this.handlePlayToggled();
-    }, this.end_time);
+      this.props.onPlayToggled(false);
+    }, endTime);
   }
 
-  handlePlayToggled(e) {
-    this.props.onPlayToggled(!this.state.play);
-    this.setState({ play: !this.state.play });
-  }
-
-  handleFavouriteToggled(e) {
-    // TODO
-    this.props.onFavouriteToggled(!this.state.favourite);
-    this.setState({ favourite: !this.state.favourite });
+  handleFavouriteClicked(e) {
+    this.props.onFavouriteToggled(!this.state.isFavourite);
+    this.setState({ isFavourite: !this.state.isFavourite });
   }
 
   getImage() {
@@ -69,20 +58,19 @@ class Robot extends Component {
       <div className="robot">
         <div className="robot-toolbar">
           <MDBIcon
-            far={!this.state.play}
-            fas={this.state.play}
+            far
             size="lg"
-            icon="play-circle"
+            icon={this.props.isPlaying ? "pause-circle" : "play-circle"}
             className="toolbar-btn"
-            onClick={this.handlePlayClick}
+            onClick={this.handlePlayClicked}
           />
           <MDBIcon
-            far={!this.state.favourite}
-            fas={this.state.favourite}
+            far={!this.state.isFavourite}
+            fas={this.state.isFavourite}
             size="lg"
             icon="star"
             className="toolbar-btn"
-            onClick={this.handleFavouriteToggled}
+            onClick={this.handleFavouriteClicked}
           />
         </div>
         <Melody melody={this.props.melody}></Melody>

--- a/client/src/Components/Robot.js
+++ b/client/src/Components/Robot.js
@@ -60,7 +60,7 @@ class Robot extends Component {
           <MDBIcon
             far
             size="lg"
-            icon={this.props.isPlaying ? "pause-circle" : "play-circle"}
+            icon={this.props.isPlaying ? "stop-circle" : "play-circle"}
             className="toolbar-btn"
             onClick={this.handlePlayClicked}
           />

--- a/client/src/Components/TopPanel.js
+++ b/client/src/Components/TopPanel.js
@@ -15,6 +15,7 @@ class TopPanel extends Component {
             <MDBCol key={i} size="3">
               <Robot
                 melody={bot.melody}
+                onPlayToggled={(play) => this.props.onPlayToggled(i, play)}
                 onFavouriteToggled={(favourite) => this.props.onFavouriteToggled(i, favourite)}
               ></Robot>
             </MDBCol>

--- a/client/src/Components/TopPanel.js
+++ b/client/src/Components/TopPanel.js
@@ -5,6 +5,20 @@ import Robot from "./Robot";
 import "./styles/TopPanel.css";
 
 class TopPanel extends Component {
+  constructor() {
+    super();
+    // TODO: stop robots from playing if composition is playing.
+    // Keep track of robot currently playing melody, if any. Only one may play at a time.
+    this.state = { robotPlaying: -1 };
+    this.handlePlayToggled = this.handlePlayToggled.bind(this);
+  }
+
+  handlePlayToggled(i, isPlaying) {
+    if (isPlaying) this.setState({ robotPlaying: i });
+    else this.setState({ robotPlaying: -1 });
+    this.props.onPlayToggled(i, isPlaying);
+  }
+
   render() {
     if (!this.props.bots) return null;
 
@@ -15,8 +29,9 @@ class TopPanel extends Component {
             <MDBCol key={i} size="3">
               <Robot
                 melody={bot.melody}
-                onPlayToggled={(play) => this.props.onPlayToggled(i, play)}
-                onFavouriteToggled={(favourite) => this.props.onFavouriteToggled(i, favourite)}
+                isPlaying={this.state.robotPlaying === i}
+                onPlayToggled={(isPlaying) => this.handlePlayToggled(i, isPlaying)}
+                onFavouriteToggled={(isFavourite) => this.props.onFavouriteToggled(i, isFavourite)}
               ></Robot>
             </MDBCol>
           ))}

--- a/client/src/Utils/melody.js
+++ b/client/src/Utils/melody.js
@@ -4,7 +4,6 @@ export const NOTE_LOWEST = 12; // F3
 export const NOTE_HIGHEST = 27; // G5
 
 export const play = (melody) => {
-  Tone.Transport.clear();
   const synth = new Tone.Synth().toMaster();
   const sequence = new Tone.Sequence(
     function (time, note) {


### PR DESCRIPTION
Changes:
- clicking the play button will change the icon
- the icon will return to normal after playback is completed
- if you click it again while it's still playing it'll stop the playback and toggle the button back 
- if you click multiple in a row they don't overlap playback, only the last one will play

Bug:
- currently if you click a bunch in a row, only the last one will have the play button return to normal after playback is finished.
- this is because of the `Tone.Transport.cancel();` on line 38 in Robot.js, it'll cancel everything in the timeline, including the function to toggle the play button back after playback is completed. Need 2 resolve