### PR TITLE
Decouple GA population from frontend

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -29,7 +29,7 @@ class App extends Component {
   }
 
   async generateBots() {
-    const response = await fetchJson("/createbots/rating", {
+    const response = await fetchJson("/bots", {
       method: "POST",
       body: JSON.stringify({
         bots: this.state.bots,

--- a/server/src/app/app.ts
+++ b/server/src/app/app.ts
@@ -4,6 +4,8 @@ import { MetadataCache } from "./MetadataCache";
 import { GaWorker } from "../ga/GaWorker";
 import { parseBotsFromReq } from "../utils/Utils";
 
+const GA_CONFIG = GaWorker.defaultConfig();
+
 const express = require("express"); // Must use a require statement for testing for unknown reason
 const app = express();
 
@@ -32,35 +34,23 @@ app.use((req, _res, next) => {
 });
 
 /**
- * Expected request body
- * {fitness}
+ * See GaWorkerConfig interface in GaWorker.ts for all configurable fields
  * Purpose: Feature flagging via API configuration
  */
 app.post("/config", async (req, res) => {
-  if (req.body.mutationRate) {
-    GaWorker.MUTATION_RATE = Number(req.body.mutationRate);
-  }
+  if (req.body.iterations) GA_CONFIG.iterations = Number(req.body.iterations);
+  if (req.body.populationSize) GA_CONFIG.populationSize = Number(req.body.populationSize);
+  if (req.body.mutationRate) GA_CONFIG.mutationRate = Number(req.body.mutationRate);
+  if (req.body.noFavourateRate) GA_CONFIG.noFavourateRate = Number(req.body.noFavourateRate);
+  if (req.body.musicalFitnessWeight)
+    GA_CONFIG.musicalFitnessWeight = Number(req.Number.musicalFitnessWeight);
+  if (req.body.selectionSize) GA_CONFIG.selectionSize = Number(req.body.selectionSize);
 
-  if (req.body.iterations) {
-    GaWorker.ITERATIONS = Number(req.body.iterations);
-  }
-
-  if (req.body.noFavourateRate) {
-    GaWorker.NO_FAVOURITE_RATE = Number(req.body.noFavourateRate);
-  }
-
-  if (req.body.musicalFitnessWeight) {
-    GaWorker.MUSICAL_FITNESS_WEIGHT = Number(req.body.musicalFitnessWeight);
-  }
-
-  res.sendStatus(200);
+  res.status(200).json(GA_CONFIG);
 });
 
 app.get("/config", async (_req, res) => {
-  res.status(200).json({
-    iterations: GaWorker.ITERATIONS,
-    mutationRate: GaWorker.MUTATION_RATE,
-  });
+  res.status(200).json(GA_CONFIG);
 });
 
 /**

--- a/server/src/app/app.ts
+++ b/server/src/app/app.ts
@@ -42,7 +42,7 @@ app.post("/config", async (req, res) => {
   if (req.body.mutationRate) GA_CONFIG.mutationRate = Number(req.body.mutationRate);
   if (req.body.noFavourateRate) GA_CONFIG.noFavourateRate = Number(req.body.noFavourateRate);
   if (req.body.musicalFitnessWeight)
-    GA_CONFIG.musicalFitnessWeight = Number(req.Number.musicalFitnessWeight);
+    GA_CONFIG.musicalFitnessWeight = Number(req.body.musicalFitnessWeight);
   if (req.body.randomInitial) GA_CONFIG.randomInitial = Boolean(req.body.randomInitial);
   if (req.body.populationSize) GA_CONFIG.populationSize = Number(req.body.populationSize);
   if (req.body.selectionSize) GA_CONFIG.selectionSize = Number(req.body.selectionSize);

--- a/server/src/app/app.ts
+++ b/server/src/app/app.ts
@@ -39,11 +39,12 @@ app.use((req, _res, next) => {
  */
 app.post("/config", async (req, res) => {
   if (req.body.iterations) GA_CONFIG.iterations = Number(req.body.iterations);
-  if (req.body.populationSize) GA_CONFIG.populationSize = Number(req.body.populationSize);
   if (req.body.mutationRate) GA_CONFIG.mutationRate = Number(req.body.mutationRate);
   if (req.body.noFavourateRate) GA_CONFIG.noFavourateRate = Number(req.body.noFavourateRate);
   if (req.body.musicalFitnessWeight)
     GA_CONFIG.musicalFitnessWeight = Number(req.Number.musicalFitnessWeight);
+  if (req.body.randomInitial) GA_CONFIG.randomInitial = Boolean(req.body.randomInitial);
+  if (req.body.populationSize) GA_CONFIG.populationSize = Number(req.body.populationSize);
   if (req.body.selectionSize) GA_CONFIG.selectionSize = Number(req.body.selectionSize);
 
   res.status(200).json(GA_CONFIG);
@@ -74,7 +75,7 @@ app.get("/data", async (_req, res) => {
 app.post("/bots", async (req, res) => {
   let bots;
   let generation = 0;
-  const worker = new GaWorker();
+  const worker = new GaWorker(GA_CONFIG);
   if (!req.body.bots || (req.body.bots && req.body.bots.length === 0)) {
     const ip = req.headers["x-forwarded-for"] || req.connection.remoteAddress;
     console.log(`First request initialized from ${ip}`);
@@ -86,9 +87,7 @@ app.post("/bots", async (req, res) => {
     bots = worker.generateNewBots(reqBots);
     generation = req.body.generation + 1;
   }
-
   MetadataCache.addGeneration(bots, generation);
-
   res.status(200).json({ bots, generation });
 });
 

--- a/server/src/app/app.ts
+++ b/server/src/app/app.ts
@@ -40,7 +40,7 @@ app.use((req, _res, next) => {
 app.post("/config", async (req, res) => {
   if (req.body.iterations) GA_CONFIG.iterations = Number(req.body.iterations);
   if (req.body.mutationRate) GA_CONFIG.mutationRate = Number(req.body.mutationRate);
-  if (req.body.noFavourateRate) GA_CONFIG.noFavourateRate = Number(req.body.noFavourateRate);
+  if (req.body.noFavourateWeight) GA_CONFIG.noFavourateWeight = Number(req.body.noFavourateWeight);
   if (req.body.musicalFitnessWeight)
     GA_CONFIG.musicalFitnessWeight = Number(req.body.musicalFitnessWeight);
   if (req.body.randomInitial) GA_CONFIG.randomInitial = Boolean(req.body.randomInitial);

--- a/server/src/app/app.ts
+++ b/server/src/app/app.ts
@@ -71,7 +71,7 @@ app.get("/data", async (_req, res) => {
  * Expected request body
  * {bots : [{metric, melody}, {...}, ...]}
  */
-app.post("/createbots/rating", async (req, res) => {
+app.post("/bots", async (req, res) => {
   let bots;
   let generation = 0;
   const worker = new GaWorker();

--- a/server/src/ga/FitnessConvention.ts
+++ b/server/src/ga/FitnessConvention.ts
@@ -61,8 +61,8 @@ export const evaluateWhoop = (melody: Melody): number => {
   return whoopFitness;
 };
 
-export const getUserFitness = (bot: Bot, noFavouriteRate: number) => {
-  return bot.metric != 0 ? bot.metric : noFavouriteRate;
+export const getUserFitness = (bot: Bot, noFavouriteWeight: number) => {
+  return bot.metric != 0 ? bot.metric : noFavouriteWeight;
 };
 
 // Fitness will be determined from the combined fitness of musical rules.
@@ -73,8 +73,8 @@ export const getMusicalFitness = (bot: Bot) => {
   );
 };
 
-export default (bots: Bot[], noFavouriteRate: number, musicalFitnessWeight: number): number[] => {
+export default (bots: Bot[], noFavouriteWeight: number, musicalFitnessWeight: number): number[] => {
   return bots.map((bot) => {
-    return getUserFitness(bot, noFavouriteRate) + musicalFitnessWeight * getMusicalFitness(bot);
+    return getUserFitness(bot, noFavouriteWeight) + musicalFitnessWeight * getMusicalFitness(bot);
   });
 };

--- a/server/src/ga/FitnessConvention.ts
+++ b/server/src/ga/FitnessConvention.ts
@@ -1,7 +1,6 @@
 import { Bot } from "../models/Bot";
 import { Melody } from "../models/Melody";
 import { OCTAVE } from "../models/Note";
-import { GaWorker } from "./GaWorker";
 
 const MAX_MELODY_SCORE = 3;
 
@@ -62,17 +61,20 @@ export const evaluateWhoop = (melody: Melody): number => {
   return whoopFitness;
 };
 
-export const getUserFitness = (bot: Bot) => {
-  return bot.metric != 0 ? bot.metric : GaWorker.NO_FAVOURITE_RATE;
-}
+export const getUserFitness = (bot: Bot, noFavouriteRate: number) => {
+  return bot.metric != 0 ? bot.metric : noFavouriteRate;
+};
 
 // Fitness will be determined from the combined fitness of musical rules.
 export const getMusicalFitness = (bot: Bot) => {
-  return (evaluateRange(bot.melody) + evaluateStepwise(bot.melody) + evaluateWhoop(bot.melody)) / MAX_MELODY_SCORE;
-}
+  return (
+    (evaluateRange(bot.melody) + evaluateStepwise(bot.melody) + evaluateWhoop(bot.melody)) /
+    MAX_MELODY_SCORE
+  );
+};
 
-export default (bots: Bot[]): number[] => {
+export default (bots: Bot[], noFavouriteRate: number, musicalFitnessWeight: number): number[] => {
   return bots.map((bot) => {
-    return getUserFitness(bot) + GaWorker.MUSICAL_FITNESS_WEIGHT * getMusicalFitness(bot);
+    return getUserFitness(bot, noFavouriteRate) + musicalFitnessWeight * getMusicalFitness(bot);
   });
 };

--- a/server/src/ga/GaWorker.ts
+++ b/server/src/ga/GaWorker.ts
@@ -62,7 +62,7 @@ export class GaWorker {
       // Run GA once with randomly generated initial population
       const set = this.createStartSet();
       const initialMelodies = randomInitialization(set, this.config.selectionSize);
-      const bots = initialMelodies.map((melody) => new Bot(0, Melody.fromString(melody)));
+      const bots = initialMelodies.map((melody) => new Bot(0, melody));
       return this.generateNewBots(bots);
     } else {
       // Return pregenerated melodies

--- a/server/src/ga/GaWorker.ts
+++ b/server/src/ga/GaWorker.ts
@@ -21,7 +21,7 @@ import { StepwiseRule } from "../rules/StepwiseRule";
 interface GaWorkerConfig {
   iterations: number; // Times GA will iterate
   mutationRate: number; // Probability of mutation
-  noFavourateRate: number; // Weight of selection is weaker if bot not favourited
+  noFavourateWeight: number; // User fitness assigned to bots that are not favourited
   musicalFitnessWeight: number; // Relative weight of melody vs user fitness in convention algo
   randomInitial: boolean; // If true, initial GA population is randomly generated
   populationSize: number; // Population size
@@ -36,7 +36,7 @@ export class GaWorker {
     return {
       iterations: 5,
       mutationRate: 0.15,
-      noFavourateRate: 0.5,
+      noFavourateWeight: 0.5,
       musicalFitnessWeight: 1,
       randomInitial: false,
       populationSize: 7,
@@ -92,7 +92,7 @@ export class GaWorker {
       // Produce fitness scores from bots
       fitnesses = evaluate(
         generation,
-        this.config.noFavourateRate,
+        this.config.noFavourateWeight,
         this.config.musicalFitnessWeight
       );
 

--- a/server/src/ga/GaWorker.ts
+++ b/server/src/ga/GaWorker.ts
@@ -19,12 +19,13 @@ import { CounterTenorRule } from "../rules/CounterTenorRule";
 import { StepwiseRule } from "../rules/StepwiseRule";
 
 interface GaWorkerConfig {
-  iterations: number;
-  mutationRate: number;
-  noFavourateRate: number;
-  musicalFitnessWeight: number;
-  populationSize: number;
-  selectionSize: number;
+  iterations: number; // Times GA will iterate
+  mutationRate: number; // Probability of mutation
+  noFavourateRate: number; // Weight of selection is weaker if bot not favourited
+  musicalFitnessWeight: number; // Relative weight of melody vs user fitness in convention algo
+  randomInitial: boolean; // If true, initial GA population is randomly generated
+  populationSize: number; // Population size
+  selectionSize: number; // Number of robots to be presented to the user
 }
 
 export class GaWorker {
@@ -33,12 +34,13 @@ export class GaWorker {
 
   static defaultConfig(): GaWorkerConfig {
     return {
-      iterations: 5, // Times GA will iterate
-      mutationRate: 0.15, // Probability of mutation
-      noFavourateRate: 0.5, // Weight of selection is weaker if bot not favourited
-      musicalFitnessWeight: 1, // Relative weight of melody vs user fitness in convention algo
-      populationSize: 7, // Population size
-      selectionSize: 7, // Number of robots to be presented to the user
+      iterations: 5,
+      mutationRate: 0.15,
+      noFavourateRate: 0.5,
+      musicalFitnessWeight: 1,
+      randomInitial: false,
+      populationSize: 7,
+      selectionSize: 7,
     };
   }
 
@@ -55,14 +57,15 @@ export class GaWorker {
     console.log(`Creating GaWorker with config: ${JSON.stringify(config, null, 2)}`);
   }
 
-  // TODO: make randomInitial configurable.
-  // TODO: on randomInitial flow, run GA.
-  initialBots(randomInitial = false): Bot[] {
-    if (randomInitial) {
+  initialBots(): Bot[] {
+    if (this.config.randomInitial) {
+      // Run GA once with randomly generated initial population
       const set = this.createStartSet();
       const initialMelodies = randomInitialization(set, this.config.selectionSize);
-      return initialMelodies.map((melody) => new Bot(0, Melody.fromString(melody)));
+      const bots = initialMelodies.map((melody) => new Bot(0, Melody.fromString(melody)));
+      return this.generateNewBots(bots);
     } else {
+      // Return pregenerated melodies
       const melodies = [
         "A4,G3,F3,E3",
         "F3,C4,B4,A4",

--- a/server/src/ga/GaWorker.ts
+++ b/server/src/ga/GaWorker.ts
@@ -1,8 +1,15 @@
+import * as _ from "lodash";
+
 import { Bot } from "../models/Bot";
 import { Rule } from "../rules/Rule";
 import { Melody } from "../models/Melody";
 import { Note } from "../models/Note";
-import { selectRandom, selectRandomWeighted, assignNoteWeights, randomInitialization } from "../utils/Utils";
+import {
+  selectRandom,
+  selectRandomMany,
+  selectRandomWeighted,
+  randomInitialization,
+} from "../utils/Utils";
 import evaluate from "./FitnessConvention";
 
 import { LeapRule } from "../rules/LeapRule";
@@ -11,18 +18,32 @@ import { OctaveRule } from "../rules/OctaveRule";
 import { CounterTenorRule } from "../rules/CounterTenorRule";
 import { StepwiseRule } from "../rules/StepwiseRule";
 
-export class GaWorker {
-  // Default Values
-  static ITERATIONS = 5; // Times GA will iterate
-  // TODO decouple this
-  POPULATION_SIZE = 7; // Population size
-  static MUTATION_RATE = 0.15; // Probability of mutation
-  static NO_FAVOURITE_RATE = 0.5; // weight of selection is weaker if bot not favourited
-  static MUSICAL_FITNESS_WEIGHT = 1; // relative weight of melody vs user fitness in convention algo
+interface GaWorkerConfig {
+  iterations: number;
+  mutationRate: number;
+  noFavourateRate: number;
+  musicalFitnessWeight: number;
+  populationSize: number;
+  selectionSize: number;
+}
 
+export class GaWorker {
+  config: GaWorkerConfig;
   rules: Rule[];
 
-  constructor() {
+  static defaultConfig(): GaWorkerConfig {
+    return {
+      iterations: 5, // Times GA will iterate
+      mutationRate: 0.15, // Probability of mutation
+      noFavourateRate: 0.5, // Weight of selection is weaker if bot not favourited
+      musicalFitnessWeight: 1, // Relative weight of melody vs user fitness in convention algo
+      populationSize: 7, // Population size
+      selectionSize: 7, // Number of robots to be presented to the user
+    };
+  }
+
+  constructor(config: GaWorkerConfig) {
+    this.config = config;
     this.rules = [
       new LeapRule(),
       new TritoneRule(),
@@ -31,55 +52,45 @@ export class GaWorker {
       new CounterTenorRule(),
     ];
 
-    console.log(`
-      Creating GaWorker with configs: 
-      iterations - ${GaWorker.ITERATIONS} , 
-      mutation_rate - ${GaWorker.MUTATION_RATE}
-    `);
+    console.log(`Creating GaWorker with config: ${JSON.stringify(config, null, 2)}`);
   }
 
-  /*
-      "A4,G3,F3,E3",
-      "F3,C4,B4,A4",
-      "C4,B4,A4,C4",
-   */
-
-  initialBots(randomInitial=false): Bot[] {
-
-    if(randomInitial){
-
-      let set = this.createStartSet();
-      let initialMelodies = randomInitialization(set, this.POPULATION_SIZE);
-      return initialMelodies.map((str) => new Bot(0, Melody.fromString(str)))
-
-    }else{
-
-      return [
+  // TODO: make randomInitial configurable.
+  // TODO: on randomInitial flow, run GA.
+  initialBots(randomInitial = false): Bot[] {
+    if (randomInitial) {
+      const set = this.createStartSet();
+      const initialMelodies = randomInitialization(set, this.config.selectionSize);
+      return initialMelodies.map((melody) => new Bot(0, Melody.fromString(melody)));
+    } else {
+      const melodies = [
+        "A4,G3,F3,E3",
+        "F3,C4,B4,A4",
+        "C4,B4,A4,C4",
         "C4,G4,G4,F4",
         "A4,B4,G4,E4",
         "G4,B4,D5,E5",
         "E4,E4,E4,A4",
         "B4,A4,G4,D4",
         "D4,G4,C5,D5",
-        "E4,G4,E4,D4"
-      ].map((str) => new Bot(0, Melody.fromString(str)));
-
+        "E4,G4,E4,D4",
+      ];
+      const selectedMelodies = selectRandomMany(melodies, this.config.selectionSize);
+      return selectedMelodies.map((melody) => new Bot(0, Melody.fromString(melody)));
     }
-    
   }
 
   generateNewBots(startingPopulation: Bot[]): Bot[] {
     let generation = startingPopulation;
+    let fitnesses;
 
     // Number of generations to iterate before returning to client
-    for (let i = 0; i < GaWorker.ITERATIONS; i++) {
-      // Feature flagging
-
+    for (let i = 0; i < this.config.iterations; i++) {
       // Produce fitness scores from bots
-      let fitnesses = evaluate(generation);
+      fitnesses = evaluate(generation);
 
       // Normalize the scores to select a new generation
-      generation = selectRandomWeighted(generation, fitnesses, this.POPULATION_SIZE);
+      generation = selectRandomWeighted(generation, fitnesses, this.config.populationSize);
 
       // Apply mutations in accordance with ruleset
       generation.forEach((bot) => this.mutateBot(bot));
@@ -88,25 +99,32 @@ export class GaWorker {
     // Reset metrics for new generation
     generation.forEach((bot) => (bot.metric = 0));
 
+    // Sort bots by fitness, descending, then select most fit bots
+    // TODO: introduce random weighted sorting
+    const selection = _.zip(generation, fitnesses)
+      .sort((a: any[], b: any[]) => b[1] - a[1])
+      .map((botWithFitness) => botWithFitness[0])
+      .slice(0, this.config.selectionSize);
+
     // Ensure favourited robots are persisted
     startingPopulation.forEach((bot, i) => {
-      if (bot.metric === 1) generation[i] = bot;
+      if (bot.metric === 1) selection[i] = bot;
     });
 
-    return generation;
+    return selection;
   }
 
   private mutateBot(bot: Bot): void {
     // Expected value of ~1 mutation per bot.
     for (var index = 0; index < bot.melody.notes.length; index++) {
-      if (Math.random() < GaWorker.MUTATION_RATE) {
+      if (Math.random() < this.config.mutationRate) {
         const notes = this.getPossibleNotesFromRules(index, bot);
-        const weights = assignNoteWeights(index, notes, bot.melody);
         if (!notes.length) {
           return;
         }
 
-        //bot.melody.notes[index] = selectRandomWeighted(notes, weights, 1)[0];
+        // const weights = assignNoteWeights(index, notes, bot.melody);
+        // bot.melody.notes[index] = selectRandomWeighted(notes, weights, 1)[0];
         bot.melody.notes[index] = selectRandom(notes);
       }
     }
@@ -138,5 +156,4 @@ export class GaWorker {
 
     return startSet.map((s: string) => Note.fromString(s));
   }
-
 }

--- a/server/src/ga/GaWorker.ts
+++ b/server/src/ga/GaWorker.ts
@@ -90,7 +90,11 @@ export class GaWorker {
     // Number of generations to iterate before returning to client
     for (let i = 0; i < this.config.iterations; i++) {
       // Produce fitness scores from bots
-      fitnesses = evaluate(generation);
+      fitnesses = evaluate(
+        generation,
+        this.config.noFavourateRate,
+        this.config.musicalFitnessWeight
+      );
 
       // Normalize the scores to select a new generation
       generation = selectRandomWeighted(generation, fitnesses, this.config.populationSize);

--- a/server/src/utils/Utils.ts
+++ b/server/src/utils/Utils.ts
@@ -106,16 +106,8 @@ export const assignNoteWeights = (index: number, mut_notes: Array<Note>, melody:
 };
 
 // Random initializes melodies for a starting population
-export const randomInitialization = (set: Array<Note>, populationSize: number) => {
-  let initialMelodies = new Array<string>();
-  let melody = new Array<string>();
+export const randomInitialization = (notes: Note[], populationSize: number): Melody[] => {
   // TODO: this 4 should be a constant somewhere.
   let melodyLength = 4;
-
-  for (let i = 0; i < populationSize; i++) {
-    melody = selectRandomMany(set, melodyLength);
-    initialMelodies.push(melody.join(","));
-  }
-
-  return initialMelodies;
+  return _.times(populationSize, () => new Melody(selectRandomMany(notes, melodyLength)));
 };

--- a/server/src/utils/Utils.ts
+++ b/server/src/utils/Utils.ts
@@ -12,8 +12,13 @@ export const parseBotsFromReq = (req) => {
 };
 
 export const selectRandom = (items) => {
-  if (!items.length) throw new Error("Empty items!");
-  return items[Math.floor(Math.random() * items.length)];
+  if (!items.length) throw new Error("Array cannot be empty");
+  items[Math.floor(Math.random() * items.length)];
+};
+
+export const selectRandomMany = (items, n) => {
+  if (!items.length) throw new Error("Array cannot be empty");
+  return _.times(n, () => items[Math.floor(Math.random() * items.length)]);
 };
 
 export const selectRandomWeighted = (items, weights, n) => {
@@ -40,21 +45,20 @@ export const selectRandomWeighted = (items, weights, n) => {
   }
 
   return choices;
-  
 };
 
 // Function to assign weights to possible notes for mutation
 export const assignNoteWeights = (index: number, mut_notes: Array<Note>, melody: Melody) => {
   let noteWeights = new Array();
-  
+
   const notes = melody.notes.map((note) => note.code);
   const mut_notes_num = mut_notes.map((note) => note.code);
   const minNote = Math.min(...notes);
   const maxNote = Math.max(...notes);
 
-  for (let i = 0; i < mut_notes.length; i++){
+  for (let i = 0; i < mut_notes.length; i++) {
     let weight = 0;
-    
+
     // Weighting based on octave range
     // If notes are within 1.5 of an octave, full fitness score awarded
     // Other wise, fitness score is assigned as 1/(octave range it covers)
@@ -62,8 +66,8 @@ export const assignNoteWeights = (index: number, mut_notes: Array<Note>, melody:
     const octaveRange = 1.5;
     let octaveWeight = 0;
     if (maxNote - mut_notes_num[i] < octave * octaveRange && mut_notes_num[i] - minNote) {
-      octaveWeight= 1;
-    }else{
+      octaveWeight = 1;
+    } else {
       let octDiff1 = Math.abs(minNote - mut_notes_num[i]);
       let octDiff2 = Math.abs(maxNote - mut_notes_num[i]);
       let octDiff = Math.max(octDiff1, octDiff2);
@@ -76,24 +80,24 @@ export const assignNoteWeights = (index: number, mut_notes: Array<Note>, melody:
     // Otherwise, fitness score is assigned as 1/(difference in notes)
     let stepWeight = 0;
     let noteDiff = 0;
-    if (index == 0){
-      noteDiff = Math.abs(notes[index+1] - mut_notes_num[i]);
-    } else if( index == melody.notes.length - 1){
-      noteDiff = Math.abs(notes[index-1] - mut_notes_num[i]);
+    if (index == 0) {
+      noteDiff = Math.abs(notes[index + 1] - mut_notes_num[i]);
+    } else if (index == melody.notes.length - 1) {
+      noteDiff = Math.abs(notes[index - 1] - mut_notes_num[i]);
     } else {
-      let noteDiff1 = Math.abs(notes[index-1] - mut_notes_num[i]);
-      let noteDiff2 = Math.abs(notes[index+1] - mut_notes_num[i]);
-      noteDiff = Math.max(noteDiff1,noteDiff2);
+      let noteDiff1 = Math.abs(notes[index - 1] - mut_notes_num[i]);
+      let noteDiff2 = Math.abs(notes[index + 1] - mut_notes_num[i]);
+      noteDiff = Math.max(noteDiff1, noteDiff2);
     }
 
     if (noteDiff <= 1) {
       stepWeight = 1;
-    } else{
+    } else {
       stepWeight = 1 / Math.abs(noteDiff);
     }
 
     // Total weighting for fitness
-    weight = (stepWeight + octaveWeight)/2;
+    weight = (stepWeight + octaveWeight) / 2;
 
     noteWeights.push(weight);
   }
@@ -102,20 +106,16 @@ export const assignNoteWeights = (index: number, mut_notes: Array<Note>, melody:
 };
 
 // Random initializes melodies for a starting population
-export const randomInitialization = (set: Array<Note>, pop_size: number) => {
+export const randomInitialization = (set: Array<Note>, populationSize: number) => {
   let initialMelodies = new Array<string>();
-  let index = 0;
   let melody = new Array<string>();
+  // TODO: this 4 should be a constant somewhere.
   let melodyLength = 4;
 
-  for (let i = 0; i < pop_size; i++){
-    melody = [];
-    for (let j = 0; j < melodyLength; j++){
-      melody.push(selectRandom(set).note);
-    }
-    initialMelodies.push(melody.join(','));
+  for (let i = 0; i < populationSize; i++) {
+    melody = selectRandomMany(set, melodyLength);
+    initialMelodies.push(melody.join(","));
   }
 
   return initialMelodies;
-
-}
+};

--- a/server/src/utils/Utils.ts
+++ b/server/src/utils/Utils.ts
@@ -13,7 +13,7 @@ export const parseBotsFromReq = (req) => {
 
 export const selectRandom = (items) => {
   if (!items.length) throw new Error("Array cannot be empty");
-  items[Math.floor(Math.random() * items.length)];
+  return items[Math.floor(Math.random() * items.length)];
 };
 
 export const selectRandomMany = (items, n) => {


### PR DESCRIPTION
- Decouple GA population parameter from the number of bots displayed in the frontend
- Move GA configuration into an object (will prevent bugs when running experiments due to tests running in parallel)
- Change `/createbots/rating` to `/bots`
- Linting